### PR TITLE
feat: Create a client-side paraphrasing tool

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Paraphrasing Tool</title>
+    <link rel="stylesheet" href="style.css">
+    <!-- winkNLP (and its model) for Part-of-Speech tagging -->
+    <script src="https://cdn.jsdelivr.net/npm/wink-nlp@1.1.0/dist/wink-nlp-bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/wink-eng-lite-model@1.1.0/dist/wink-eng-lite-model-bundle.min.js"></script>
+</head>
+<body>
+    <div class="container">
+        <h1>Paraphrasing Tool</h1>
+        <p>Enter your text below to paraphrase it.</p>
+        <textarea id="inputText" placeholder="Enter text here..."></textarea>
+        <div class="controls">
+            <div class="control-group">
+                <label for="mode">Mode:</label>
+                <select id="mode">
+                    <option value="standard">Standard</option>
+                    <option value="creative">Creative</option>
+                </select>
+            </div>
+            <div class="control-group">
+                <label for="level">Level:</label>
+                <input type="range" id="level" min="0" max="100" value="50">
+                <span id="levelValue">50%</span>
+            </div>
+        </div>
+        <button id="paraphraseBtn">Paraphrase</button>
+        <div id="outputContainer">
+            <h2>Paraphrased Text:</h2>
+            <p id="outputText"></p>
+        </div>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,86 @@
+document.addEventListener('DOMContentLoaded', () => {
+    // Get references to all the necessary DOM elements
+    const inputText = document.getElementById('inputText');
+    const paraphraseBtn = document.getElementById('paraphraseBtn');
+    const outputText = document.getElementById('outputText');
+    const modeSelect = document.getElementById('mode');
+    const levelSlider = document.getElementById('level');
+    const levelValue = document.getElementById('levelValue');
+
+    // Initialize winkNLP with the English lite model
+    // This is used for Part-of-Speech (POS) tagging
+    const nlp = window.winkNLP(window.winkEngLiteModel);
+    const its = nlp.its;
+
+    // Define which Part-of-Speech tags we want to replace.
+    // We avoid replacing pronouns, prepositions, etc. to maintain sentence structure.
+    const replaceablePOS = ['NOUN', 'VERB', 'ADJ', 'ADV'];
+
+    // Add an event listener to the slider to update the percentage display
+    levelSlider.addEventListener('input', () => {
+        levelValue.textContent = `${levelSlider.value}%`;
+    });
+
+    // Add the main event listener for the paraphrase button
+    paraphraseBtn.addEventListener('click', async () => {
+        const text = inputText.value.trim();
+        if (text === '') {
+            outputText.textContent = 'Please enter some text to paraphrase.';
+            return;
+        }
+
+        // Provide feedback to the user that the process has started
+        outputText.textContent = 'Paraphrasing...';
+
+        // Get the selected mode and level from the controls
+        const mode = modeSelect.value;
+        const level = levelSlider.value;
+        const apiParam = mode === 'creative' ? 'rel_trg' : 'rel_syn';
+
+        try {
+            // Process the text with winkNLP to get tokens and their POS tags
+            const doc = nlp.readDoc(text);
+            const tokens = doc.tokens().out(its.text, its.pos);
+
+            // Create an array of promises, one for each token
+            const paraphrasedWords = await Promise.all(tokens.map(async (token) => {
+                // Check if the token's POS is replaceable and if it passes the random level check
+                if (replaceablePOS.includes(token.pos) && Math.random() < level / 100) {
+                    const word = token.text;
+                    // Simple punctuation handling: strip it, find synonym, re-attach it.
+                    const punctuation = word.match(/[.,\/#!$%\^&\*;:{}=\-_`~()]/g) || [];
+                    const cleanWord = word.replace(/[.,\/#!$%\^&\*;:{}=\-_`~()]/g, '');
+
+                    if (cleanWord === '') {
+                        return word; // It was just punctuation
+                    }
+
+                    // Call the Datamuse API to get related words
+                    const response = await fetch(`https://api.datamuse.com/words?${apiParam}=${cleanWord}&max=5`);
+                    if (!response.ok) {
+                        return word; // Return original word on API error
+                    }
+                    const results = await response.json();
+
+                    if (results.length > 0) {
+                        // Pick the first result and re-attach punctuation
+                        return results[0].word + punctuation.join('');
+                    } else {
+                        return word; // Return original word if no synonyms found
+                    }
+                } else {
+                    // If the word is not replaceable, return it as is
+                    return token.text;
+                }
+            }));
+
+            // Join the words back into a sentence and display the result
+            // Includes a simple fix for spacing around punctuation.
+            outputText.textContent = paraphrasedWords.join(' ').replace(/ \./g, '.').replace(/ ,/g, ',');
+
+        } catch (error) {
+            console.error('Error paraphrasing text:', error);
+            outputText.textContent = 'Failed to paraphrase text. Please try again later.';
+        }
+    });
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,111 @@
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+    background-color: #f4f4f9;
+    color: #333;
+    line-height: 1.6;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    margin: 0;
+}
+
+.container {
+    background: #fff;
+    padding: 2rem;
+    border-radius: 8px;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    width: 90%;
+    max-width: 800px;
+    box-sizing: border-box;
+}
+
+h1 {
+    color: #0056b3;
+    text-align: center;
+    margin-bottom: 0.5rem;
+}
+
+p {
+    text-align: center;
+    margin-bottom: 1.5rem;
+    color: #666;
+}
+
+textarea {
+    width: 100%;
+    height: 150px;
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    margin-bottom: 1rem;
+    box-sizing: border-box;
+    resize: vertical;
+}
+
+button {
+    display: block;
+    width: 100%;
+    padding: 10px 15px;
+    background-color: #007bff;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 1rem;
+    transition: background-color 0.3s ease;
+}
+
+button:hover {
+    background-color: #0056b3;
+}
+
+.controls {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+    flex-wrap: wrap;
+}
+
+.control-group {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+select, input[type="range"] {
+    padding: 5px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+}
+
+#outputContainer {
+    margin-top: 2rem;
+    padding: 1rem;
+    background-color: #f9f9f9;
+    border: 1px solid #eee;
+    border-radius: 4px;
+}
+
+#outputContainer h2 {
+    margin-top: 0;
+    color: #333;
+}
+
+#outputText {
+    text-align: left;
+    color: #555;
+}
+
+/* Responsive Design */
+@media (max-width: 600px) {
+    .container {
+        padding: 1rem;
+    }
+
+    h1 {
+        font-size: 1.5rem;
+    }
+}


### PR DESCRIPTION
This commit introduces a new single-page web application that functions as a paraphrasing tool.

The tool is built using HTML, CSS, and vanilla JavaScript, and it runs entirely on the client-side. It leverages the free Datamuse API for finding synonyms and related words, and the `wink-nlp` library for Part-of-Speech (POS) tagging to ensure that only appropriate words (nouns, verbs, adjectives, adverbs) are replaced.

Features:
- Responsive design for various screen sizes.
- Two paraphrasing modes: 'Standard' (for synonyms) and 'Creative' (for statistically associated words).
- A slider to control the level/intensity of paraphrasing.
- POS tagging to produce more grammatically correct results.